### PR TITLE
Fix app to show upcoming matches screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ flutter_export_environment.sh
 **/Generated.xcconfig
 **/flutter_export_environment.sh
 
+# Node.js
+package-lock.json
+
 # OSX, Linux etc
 .DS_Store
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,11 +12,12 @@ class FootballIsLifeApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'Football is Life',
       theme: ThemeData(
         primarySwatch: Colors.green,
       ),
-      home: UpcomingMatchesScreen(),
+      home: const UpcomingMatchesScreen(),
     );
   }
 }

--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -4,7 +4,7 @@ import '../models/match.dart';
 import 'match_detail_screen.dart';
 
 class UpcomingMatchesScreen extends StatelessWidget {
-  UpcomingMatchesScreen({Key? key}) : super(key: key);
+  const UpcomingMatchesScreen({Key? key}) : super(key: key);
 
   final List<Match> matches = [
     Match(


### PR DESCRIPTION
## Summary
- hide debug banner and use upcoming matches as home screen
- make upcoming matches screen constant
- ignore Node lock file

## Testing
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68965af47cd083298df652c1debe801d