### PR TITLE
Fix constant expression error in UpcomingMatchesScreen

### DIFF
--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -6,7 +6,7 @@ import 'match_detail_screen.dart';
 class UpcomingMatchesScreen extends StatelessWidget {
   const UpcomingMatchesScreen({Key? key}) : super(key: key);
 
-  final List<Match> matches = [
+  static final List<Match> matches = [
     Match(
       id: '1',
       title: 'Friendly Kickoff',


### PR DESCRIPTION
## Summary
- make `matches` list static to avoid const field initialization errors in `UpcomingMatchesScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68965ef334748329a41a369628d9b482