### PR TITLE
Add mock login flow and personalize matches screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'screens/upcoming_matches_screen.dart';
+import 'screens/login_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const UpcomingMatchesScreen(),
+      home: const LoginScreen(),
     );
   }
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,12 @@
+class User {
+  final String name;
+  final String phone;
+  final DateTime joinDate;
+
+  User({
+    required this.name,
+    required this.phone,
+    required this.joinDate,
+  });
+}
+

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../models/user.dart';
+import 'upcoming_matches_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  void _login() {
+    final user = User(
+      name: _nameController.text,
+      phone: _phoneController.text,
+      joinDate: DateTime.now(),
+    );
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => UpcomingMatchesScreen(user: user),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _phoneController,
+              decoration: const InputDecoration(labelText: 'Phone Number'),
+              keyboardType: TextInputType.phone,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _login,
+              child: const Text('Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
 import '../models/match.dart';
+import '../models/user.dart';
 import 'match_detail_screen.dart';
 
 class UpcomingMatchesScreen extends StatelessWidget {
-  const UpcomingMatchesScreen({Key? key}) : super(key: key);
+  final User user;
+  const UpcomingMatchesScreen({Key? key, required this.user}) : super(key: key);
 
   static final List<Match> matches = [
     Match(
@@ -41,22 +43,44 @@ class UpcomingMatchesScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Upcoming Matches'),
       ),
-      body: ListView.builder(
-        itemCount: upcoming.length,
-        itemBuilder: (context, index) {
-          final match = upcoming[index];
-          return ListTile(
-            title: Text(match.title),
-            subtitle: Text('${match.date.toLocal()}'.split(' ')[0]),
-            onTap: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => MatchDetailScreen(match: match),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Welcome, ${user.name}',
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
-              );
-            },
-          );
-        },
+                Text(
+                  'Joined on: ${user.joinDate.toLocal().toString().split(' ')[0]}',
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: upcoming.length,
+              itemBuilder: (context, index) {
+                final match = upcoming[index];
+                return ListTile(
+                  title: Text(match.title),
+                  subtitle: Text('${match.date.toLocal()}'.split(' ')[0]),
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => MatchDetailScreen(match: match),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,21 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:football_is_life/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Login and navigate to matches screen', (tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    expect(find.text('Login'), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    await tester.enterText(find.byType(TextField).at(0), 'Alice');
+    await tester.enterText(find.byType(TextField).at(1), '123456');
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    await tester.tap(find.text('Login'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Welcome, Alice'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- add User model and login screen to capture name and phone for session
- personalize upcoming matches with welcome header and join date
- update tests to cover login flow

## Testing
- `flutter format lib/main.dart lib/models/user.dart lib/screens/login_screen.dart lib/screens/upcoming_matches_screen.dart test/widget_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689660da24f88329a0153adf3abb0ff4