### PR TITLE
feat: add game creation and privacy options

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,8 +16,8 @@ class MyApp extends StatelessWidget {
       title: 'Football is Life',
       theme: ThemeData(
         colorScheme:
-            ColorScheme.fromSeed(seedColor: const Color(0xFF58CC02)),
-        scaffoldBackgroundColor: const Color(0xFFE4F8D3),
+            ColorScheme.fromSeed(seedColor: const Color(0xFF87CEFA)),
+        scaffoldBackgroundColor: const Color(0xFFE3F2FD),
       ),
       home: const LoginScreen(),
     );

--- a/lib/models/match.dart
+++ b/lib/models/match.dart
@@ -3,7 +3,9 @@ class Match {
   final String title;
   final DateTime date;
   final String location;
+  final int minPlayers;
   final int capacity;
+  final bool isPrivate;
   final List<String> attendees;
 
   Match({
@@ -11,7 +13,9 @@ class Match {
     required this.title,
     required this.date,
     required this.location,
+    required this.minPlayers,
     required this.capacity,
+    required this.isPrivate,
     required this.attendees,
   });
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -39,6 +39,7 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: const Color(0xFF87CEFA),
         title: const Text('Login'),
       ),
       body: Padding(

--- a/lib/screens/match_detail_screen.dart
+++ b/lib/screens/match_detail_screen.dart
@@ -10,6 +10,7 @@ class MatchDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: const Color(0xFF87CEFA),
         title: Text(match.title),
       ),
       body: Padding(
@@ -21,7 +22,11 @@ class MatchDetailScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Text('Location: ${match.location}'),
             const SizedBox(height: 8),
-            Text('Capacity: ${match.capacity}'),
+            Text('Min Players: ${match.minPlayers}'),
+            const SizedBox(height: 8),
+            Text('Max Players: ${match.capacity}'),
+            const SizedBox(height: 8),
+            Text('Privacy: ${match.isPrivate ? 'Private' : 'Public'}'),
             const SizedBox(height: 8),
             Text('Attendees (${match.attendees.length}/${match.capacity}):'),
             const SizedBox(height: 4),

--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -14,7 +14,9 @@ class UpcomingMatchesScreen extends StatefulWidget {
       title: 'Friendly Kickoff',
       date: DateTime.now().add(const Duration(days: 1)),
       location: 'Local Stadium',
-      capacity: 50,
+      minPlayers: 8,
+      capacity: 12,
+      isPrivate: false,
       attendees: ['Sam', 'Kim', 'Alex'],
     ),
     Match(
@@ -22,7 +24,9 @@ class UpcomingMatchesScreen extends StatefulWidget {
       title: 'Championship Qualifier',
       date: DateTime.now().add(const Duration(days: 2)),
       location: 'City Arena',
-      capacity: 100,
+      minPlayers: 8,
+      capacity: 16,
+      isPrivate: true,
       attendees: ['Jordan'],
     ),
     Match(
@@ -30,7 +34,9 @@ class UpcomingMatchesScreen extends StatefulWidget {
       title: 'Season Finale',
       date: DateTime.now().add(const Duration(days: 7)),
       location: 'Grand Arena',
-      capacity: 1000,
+      minPlayers: 10,
+      capacity: 15,
+      isPrivate: false,
       attendees: ['Dana', 'Lee'],
     ),
     Match(
@@ -38,7 +44,9 @@ class UpcomingMatchesScreen extends StatefulWidget {
       title: 'Morning Practice',
       date: DateTime.now().add(const Duration(days: 3)),
       location: 'Community Field',
-      capacity: 20,
+      minPlayers: 6,
+      capacity: 10,
+      isPrivate: false,
       attendees: ['Morgan', 'Jess'],
     ),
     Match(
@@ -46,7 +54,9 @@ class UpcomingMatchesScreen extends StatefulWidget {
       title: 'Charity Cup',
       date: DateTime.now().add(const Duration(days: 4)),
       location: 'Downtown Pitch',
-      capacity: 30,
+      minPlayers: 8,
+      capacity: 14,
+      isPrivate: true,
       attendees: ['Luis', 'Tim', 'Hana'],
     ),
     Match(
@@ -54,7 +64,9 @@ class UpcomingMatchesScreen extends StatefulWidget {
       title: 'Neighborhood League',
       date: DateTime.now().add(const Duration(days: 5)),
       location: 'Westside Grounds',
-      capacity: 40,
+      minPlayers: 8,
+      capacity: 13,
+      isPrivate: false,
       attendees: ['Ariel'],
     ),
   ];
@@ -72,6 +84,101 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen> {
     });
   }
 
+  void _showCreateMatchDialog() {
+    final titleController = TextEditingController();
+    final dateController = TextEditingController();
+    final locationController = TextEditingController();
+    final minController = TextEditingController();
+    final maxController = TextEditingController();
+    bool isPrivate = false;
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(builder: (context, setStateDialog) {
+          return AlertDialog(
+            title: const Text('Start a Game'),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: titleController,
+                    decoration: const InputDecoration(labelText: 'Title'),
+                  ),
+                  TextField(
+                    controller: dateController,
+                    decoration: const InputDecoration(
+                        labelText: 'Date (YYYY-MM-DD HH:MM)'),
+                  ),
+                  TextField(
+                    controller: locationController,
+                    decoration: const InputDecoration(labelText: 'Location'),
+                  ),
+                  TextField(
+                    controller: minController,
+                    decoration:
+                        const InputDecoration(labelText: 'Min Players'),
+                    keyboardType: TextInputType.number,
+                  ),
+                  TextField(
+                    controller: maxController,
+                    decoration: const InputDecoration(
+                        labelText: 'Max Players (10-16)'),
+                    keyboardType: TextInputType.number,
+                  ),
+                  SwitchListTile(
+                    title: const Text('Private'),
+                    value: isPrivate,
+                    onChanged: (val) {
+                      setStateDialog(() {
+                        isPrivate = val;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Cancel'),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  final maxPlayers = int.tryParse(maxController.text) ?? 0;
+                  if (maxPlayers < 10 || maxPlayers > 16) {
+                    return;
+                  }
+                  final minPlayers = int.tryParse(minController.text) ?? 0;
+                  final dateInput = dateController.text;
+                  final date =
+                      DateTime.tryParse(dateInput.replaceFirst(' ', 'T')) ??
+                          DateTime.now();
+                  final match = Match(
+                    id: DateTime.now().millisecondsSinceEpoch.toString(),
+                    title: titleController.text,
+                    date: date,
+                    location: locationController.text,
+                    minPlayers: minPlayers,
+                    capacity: maxPlayers,
+                    isPrivate: isPrivate,
+                    attendees: [],
+                  );
+                  setState(() {
+                    UpcomingMatchesScreen.matches.add(match);
+                  });
+                  Navigator.of(context).pop();
+                },
+                child: const Text('Create'),
+              ),
+            ],
+          );
+        });
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final upcoming = UpcomingMatchesScreen.matches
@@ -79,7 +186,7 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen> {
         .toList();
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: const Color(0xFF58CC02),
+        backgroundColor: const Color(0xFF87CEFA),
         title: const Text('Upcoming Matches'),
       ),
       body: Column(
@@ -106,7 +213,7 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen> {
               itemBuilder: (context, index) {
                 final match = upcoming[index];
                 return Card(
-                  color: const Color(0xFFCFF3A8),
+                  color: const Color(0xFFE1F5FE),
                   margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                   child: ListTile(
                     title: Text(
@@ -114,19 +221,21 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen> {
                       style: const TextStyle(fontWeight: FontWeight.bold),
                     ),
                     subtitle: Text(
-                      '${match.date.toLocal()}'.split(' ')[0] +
-                          ' | Players: ${match.attendees.length}/${match.capacity}',
-                    ),
+                        '${match.date.toLocal()}'.split('.').first +
+                            ' @ ${match.location}\n'
+                            'Players: ${match.attendees.length}/${match.capacity} | '
+                            '${match.isPrivate ? 'Private' : 'Public'}'),
                     trailing: ElevatedButton(
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF58CC02),
+                        backgroundColor: const Color(0xFF87CEFA),
                         foregroundColor: Colors.white,
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(8),
                         ),
                       ),
                       onPressed: () => _joinMatch(match),
-                      child: const Text('Join'),
+                      child:
+                          Text(match.isPrivate ? 'Join Waitlist' : 'Join'),
                     ),
                     onTap: () {
                       Navigator.of(context).push(
@@ -141,6 +250,13 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen> {
             ),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _showCreateMatchDialog,
+        backgroundColor: const Color(0xFF87CEFA),
+        foregroundColor: Colors.white,
+        label: const Text('Start Game'),
+        icon: const Icon(Icons.add),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow users to start matches with custom details and privacy
- show location next to time and adjust join button for private games
- switch app theme to light blue and limit match size to 10-16 players

## Testing
- `flutter test` *(command not found)*
- `sudo apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6896655008bc8329ac713693499a6be6