### PR TITLE
Improve match scheduling with waitlists and duration info

### DIFF
--- a/lib/models/match.dart
+++ b/lib/models/match.dart
@@ -7,6 +7,8 @@ class Match {
   final int capacity;
   final bool isPrivate;
   final List<String> attendees;
+  final List<String> waitlist;
+  final Duration duration;
 
   Match({
     required this.id,
@@ -17,6 +19,8 @@ class Match {
     required this.capacity,
     required this.isPrivate,
     required this.attendees,
+    required this.waitlist,
+    required this.duration,
   });
 
   bool get isUpcoming => date.isAfter(DateTime.now());

--- a/lib/screens/match_detail_screen.dart
+++ b/lib/screens/match_detail_screen.dart
@@ -18,7 +18,11 @@ class MatchDetailScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Date: ' + '${match.date.toLocal()}'.split(' ')[0]),
+            Text('Date: '
+                '${match.date.year.toString().padLeft(4, '0')}-${match.date.month.toString().padLeft(2, '0')}-${match.date.day.toString().padLeft(2, '0')}'),
+            const SizedBox(height: 8),
+            Text('Start Time: '
+                '${match.date.hour.toString().padLeft(2, '0')}:${match.date.minute.toString().padLeft(2, '0')}'),
             const SizedBox(height: 8),
             Text('Location: ${match.location}'),
             const SizedBox(height: 8),
@@ -26,16 +30,39 @@ class MatchDetailScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Text('Max Players: ${match.capacity}'),
             const SizedBox(height: 8),
-            Text('Privacy: ${match.isPrivate ? 'Private' : 'Public'}'),
+            RichText(
+              text: TextSpan(
+                text: 'Privacy: ',
+                style: DefaultTextStyle.of(context).style,
+                children: [
+                  TextSpan(
+                    text: match.isPrivate ? 'Private' : 'Public',
+                    style: TextStyle(
+                        color:
+                            match.isPrivate ? Colors.red : Colors.green),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text('Duration: ${match.duration.inMinutes} minutes'),
             const SizedBox(height: 8),
             Text('Attendees (${match.attendees.length}/${match.capacity}):'),
             const SizedBox(height: 4),
             Expanded(
-              child: ListView.builder(
-                itemCount: match.attendees.length,
-                itemBuilder: (context, index) => ListTile(
-                  title: Text(match.attendees[index]),
-                ),
+              child: ListView(
+                children: [
+                  ...match.attendees
+                      .map((a) => ListTile(title: Text(a)))
+                      .toList(),
+                  if (match.waitlist.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Text('Waitlist (${match.waitlist.length}):'),
+                    ...match.waitlist
+                        .map((w) => ListTile(title: Text(w)))
+                        .toList(),
+                  ]
+                ],
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- add duration and waitlist support to `Match`
- allow creating games with separate date/time, city selection, and 15-minute start enforcement
- show duration and privacy colors, and update join/withdraw/waitlist button logic

## Testing
- `dart format lib/models/match.dart lib/screens/upcoming_matches_screen.dart lib/screens/match_detail_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68966946d934832981dc4a5608c4fe30