### PR TITLE
Fix constant constructor usage in leagues tab

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -60,10 +60,10 @@ class _LeaguesTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('Your Leagues')),
-      body: Center(
-        child: Text('No leagues yet'),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Your Leagues')),
+      body: const Center(
+        child: const Text('No leagues yet'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- remove `const` from `Scaffold` and apply constants only where supported to fix build error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971758601c8329b5823fa26a511739