### PR TITLE
Prevent match list overflow

### DIFF
--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -406,17 +406,18 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
                             Text('$dayName $dateStr @ ${match.location}'),
                             const SizedBox(height: 4),
                             if (!match.isPrivate)
-                              Row(
+                              Wrap(
+                                spacing: 8,
+                                runSpacing: 4,
+                                crossAxisAlignment: WrapCrossAlignment.center,
                                 children: [
                                   Text(
                                       'Players: ${match.attendees.length}/${match.capacity}'),
-                                  const SizedBox(width: 8),
                                   Chip(
                                     label: const Text('Public'),
                                     backgroundColor: Colors.green.shade100,
                                     visualDensity: VisualDensity.compact,
                                   ),
-                                  const SizedBox(width: 8),
                                   Text(
                                       'Duration: ${match.duration.inMinutes}m'),
                                 ],


### PR DESCRIPTION
## Summary
- replace Row with Wrap in upcoming matches list to avoid RenderFlex overflows

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971920f4d88329b85075f9b1d0a6bb