### PR TITLE
Add football backgrounds and organize upcoming games

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -45,10 +45,23 @@ class _WelcomeTab extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Home')),
-      body: Center(
-        child: Text(
-          'Welcome, ${user.name}!',
-          style: const TextStyle(fontSize: 24),
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: NetworkImage(
+                'https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=800&q=80'),
+            fit: BoxFit.cover,
+            colorFilter: ColorFilter.mode(
+              Colors.black38,
+              BlendMode.darken,
+            ),
+          ),
+        ),
+        child: Center(
+          child: Text(
+            'Welcome, ${user.name}!',
+            style: const TextStyle(fontSize: 24, color: Colors.white),
+          ),
         ),
       ),
     );
@@ -62,8 +75,24 @@ class _LeaguesTab extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Your Leagues')),
-      body: const Center(
-        child: const Text('No leagues yet'),
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: NetworkImage(
+                'https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=800&q=80'),
+            fit: BoxFit.cover,
+            colorFilter: ColorFilter.mode(
+              Colors.black38,
+              BlendMode.darken,
+            ),
+          ),
+        ),
+        child: const Center(
+          child: Text(
+            'No leagues yet',
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/match_detail_screen.dart
+++ b/lib/screens/match_detail_screen.dart
@@ -37,58 +37,71 @@ class MatchDetailScreen extends StatelessWidget {
         backgroundColor: const Color(0xFF87CEFA),
         title: Text(match.title),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-                'Date: $dayName ${match.date.year.toString().padLeft(4, '0')}-${match.date.month.toString().padLeft(2, '0')}-${match.date.day.toString().padLeft(2, '0')}'),
-            const SizedBox(height: 8),
-            Text(
-                'Start Time: ${match.date.hour.toString().padLeft(2, '0')}:${match.date.minute.toString().padLeft(2, '0')}'),
-            const SizedBox(height: 8),
-            Text('Location: ${match.venue}'),
-            const SizedBox(height: 8),
-            Text('Min Players: ${match.minPlayers}'),
-            const SizedBox(height: 8),
-            Text('Max Players: ${match.capacity}'),
-            const SizedBox(height: 8),
-            Text('Duration: ${match.duration.inMinutes} minutes'),
-            const SizedBox(height: 8),
-            Text('Attendees (${match.attendees.length}/${match.capacity}):'),
-            const SizedBox(height: 4),
-            Expanded(
-              child: ListView(
-                children: [
-                  ...match.attendees.map((a) => Column(
-                        children: [
-                          ListTile(
-                            leading: CircleAvatar(child: Text(a[0])),
-                            title: Text(a),
-                            onTap: () => _showPlayerDialog(context, a),
-                          ),
-                          const Divider(),
-                        ],
-                      )),
-                  if (match.waitlist.isNotEmpty) ...[
-                    const SizedBox(height: 8),
-                    Text('Waitlist (${match.waitlist.length}):'),
-                    ...match.waitlist.map((w) => Column(
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: NetworkImage(
+                'https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=800&q=80'),
+            fit: BoxFit.cover,
+            colorFilter: ColorFilter.mode(
+              Colors.black38,
+              BlendMode.darken,
+            ),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                  'Date: $dayName ${match.date.year.toString().padLeft(4, '0')}-${match.date.month.toString().padLeft(2, '0')}-${match.date.day.toString().padLeft(2, '0')}'),
+              const SizedBox(height: 8),
+              Text(
+                  'Start Time: ${match.date.hour.toString().padLeft(2, '0')}:${match.date.minute.toString().padLeft(2, '0')}'),
+              const SizedBox(height: 8),
+              Text('Location: ${match.venue}'),
+              const SizedBox(height: 8),
+              Text('Min Players: ${match.minPlayers}'),
+              const SizedBox(height: 8),
+              Text('Max Players: ${match.capacity}'),
+              const SizedBox(height: 8),
+              Text('Duration: ${match.duration.inMinutes} minutes'),
+              const SizedBox(height: 8),
+              Text('Attendees (${match.attendees.length}/${match.capacity}):'),
+              const SizedBox(height: 4),
+              Expanded(
+                child: ListView(
+                  children: [
+                    ...match.attendees.map((a) => Column(
                           children: [
                             ListTile(
-                              leading: CircleAvatar(child: Text(w[0])),
-                              title: Text(w),
-                              onTap: () => _showPlayerDialog(context, w),
+                              leading: CircleAvatar(child: Text(a[0])),
+                              title: Text(a),
+                              onTap: () => _showPlayerDialog(context, a),
                             ),
                             const Divider(),
                           ],
                         )),
-                  ]
-                ],
+                    if (match.waitlist.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text('Waitlist (${match.waitlist.length}):'),
+                      ...match.waitlist.map((w) => Column(
+                            children: [
+                              ListTile(
+                                leading: CircleAvatar(child: Text(w[0])),
+                                title: Text(w),
+                                onTap: () => _showPlayerDialog(context, w),
+                              ),
+                              const Divider(),
+                            ],
+                          )),
+                    ]
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Add football background imagery to home, leagues, match details, and upcoming matches screens
- Separate upcoming matches into "Your Games" and other games grouped by week, month, and later

## Testing
- `dart format lib/screens/home_screen.dart lib/screens/upcoming_matches_screen.dart lib/screens/match_detail_screen.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*
- `dart test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971b2565508329aa1d481a6c9e963e