### PR TITLE
Revamp home and game views

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,14 +5,86 @@ import GameDetail from './components/GameDetail';
 import { subscribeUpcomingGames } from './services/games';
 import { auth } from './firebase';
 
+function HomeTab({ user, games, status, setStatus, onSelect }) {
+  const joined = games.filter(g => (g.going || []).includes(user.uid));
+  const now = Date.now();
+  const upcoming = joined.filter(g => g.startTime > now).slice(0, 3);
+  const past = joined.filter(g => g.startTime <= now).slice(-3);
+  const lastActive = user?.metadata?.lastSignInTime
+    ? new Date(user.metadata.lastSignInTime).toLocaleDateString()
+    : 'Unknown';
+  return (
+    <div>
+      <h2>Your Info</h2>
+      <p>Phone: {user.phoneNumber}</p>
+      <p>Status: {status}</p>
+      <p>Last active: {lastActive}</p>
+      <label>
+        Update status:
+        <select value={status} onChange={e => setStatus(e.target.value)}>
+          <option value="Available">Available</option>
+          <option value="Injured">Injured</option>
+          <option value="On Vacation">On Vacation</option>
+        </select>
+      </label>
+      <h3 className="mt-4">Upcoming Games</h3>
+      {upcoming.length ? upcoming.map(g => (
+        <div key={g.id} onClick={() => onSelect(g)}>
+          <GameCard game={g} />
+        </div>
+      )) : <p>No upcoming games</p>}
+      <h3 className="mt-4">Recent Games</h3>
+      {past.length ? past.map(g => (
+        <div key={g.id} onClick={() => onSelect(g)}>
+          <GameCard game={g} />
+        </div>
+      )) : <p>No past games</p>}
+    </div>
+  );
+}
+
+function GamesTab({ games, onSelect }) {
+  return (
+    <div>
+      {games.map(g => (
+        <div key={g.id} onClick={() => onSelect(g)}>
+          <GameCard game={g} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function LeaguesTab({ user, games, onSelect }) {
+  const joined = games.filter(g => (g.going || []).includes(user.uid));
+  if (!joined.length) {
+    return <p>No leagues yet. Join a game to get started.</p>;
+  }
+  return (
+    <div>
+      {joined.map(g => (
+        <div key={g.id} onClick={() => onSelect(g)}>
+          <GameCard game={g} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function App() {
   const [games, setGames] = useState([]);
   const [selected, setSelected] = useState(null);
+  const [tab, setTab] = useState('home');
+  const [status, setStatus] = useState(localStorage.getItem('status') || 'Available');
 
   useEffect(() => {
     const unsub = subscribeUpcomingGames(setGames);
     return unsub;
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('status', status);
+  }, [status]);
 
   const user = auth.currentUser;
 
@@ -20,17 +92,28 @@ export default function App() {
     <AuthGate>
       <div>
         <h1>Football Is Life</h1>
+        <nav className="space-x-4 mb-4">
+          <button onClick={() => setTab('home')}>Home</button>
+          <button onClick={() => setTab('games')}>Games</button>
+          <button onClick={() => setTab('leagues')}>Leagues</button>
+        </nav>
         {selected ? (
           <div>
             <button onClick={() => setSelected(null)}>Back</button>
             <GameDetail game={selected} user={user} />
           </div>
         ) : (
-          games.map(g => (
-            <div key={g.id} onClick={() => setSelected(g)}>
-              <GameCard game={g} />
-            </div>
-          ))
+          <>
+            {tab === 'home' && (
+              <HomeTab user={user} games={games} status={status} setStatus={setStatus} onSelect={setSelected} />
+            )}
+            {tab === 'games' && (
+              <GamesTab games={games} onSelect={setSelected} />
+            )}
+            {tab === 'leagues' && (
+              <LeaguesTab user={user} games={games} onSelect={setSelected} />
+            )}
+          </>
         )}
       </div>
     </AuthGate>

--- a/src/components/GameCard.jsx
+++ b/src/components/GameCard.jsx
@@ -1,9 +1,11 @@
 export default function GameCard({ game }) {
+  const isPublic = game.isPublic !== false;
   return (
-    <div className="border rounded p-4">
+    <div className="border rounded p-4 bg-white">
       <h3 className="font-semibold">{game.title}</h3>
       <p>{new Date(game.startTime).toLocaleString()}</p>
       <p>{(game.going ? game.going.length : 0)}/{game.cap}</p>
+      <p className="mt-2 text-sm text-gray-600">{isPublic ? 'Public' : 'Private'}</p>
     </div>
   );
 }

--- a/src/components/GameDetail.jsx
+++ b/src/components/GameDetail.jsx
@@ -19,12 +19,12 @@ export default function GameDetail({ game, user }) {
   };
 
   return (
-    <div>
+    <div className="bg-white text-black p-4 rounded shadow">
       <GameCard game={game} />
       {isGoing ? (
-        <button onClick={leave} disabled={saving}>Leave</button>
+        <button className="mt-4 px-4 py-2 bg-red-500 text-white rounded" onClick={leave} disabled={saving}>Leave</button>
       ) : (
-        <button onClick={join} disabled={saving}>Join</button>
+        <button className="mt-4 px-4 py-2 bg-green-500 text-white rounded" onClick={join} disabled={saving}>Join</button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add home, games, and leagues tabs with status tracking
- clarify game cards and details with accessible styling

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68971f67fb548329aa4d01cdba3ccc23