### PR TITLE
Enhance game cards and home/leagues tabs

### DIFF
--- a/lib/screens/match_detail_screen.dart
+++ b/lib/screens/match_detail_screen.dart
@@ -38,17 +38,7 @@ class MatchDetailScreen extends StatelessWidget {
         title: Text(match.title),
       ),
       body: Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: NetworkImage(
-                'https://images.unsplash.com/photo-1517927033932-b3d18e61fb3a?auto=format&fit=crop&w=800&q=80'),
-            fit: BoxFit.cover,
-            colorFilter: ColorFilter.mode(
-              Colors.black38,
-              BlendMode.darken,
-            ),
-          ),
-        ),
+        color: const Color(0xFFE1F5FE),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -462,22 +462,15 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
             children: [
               Text('$dayName $dateStr @ ${match.location}'),
               const SizedBox(height: 4),
-              if (!match.isPrivate)
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 4,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    Text('Players: ${match.attendees.length}/${match.capacity}'),
-                    Chip(
-                      label: const Text('Public'),
-                      backgroundColor: Colors.green.shade100,
-                      visualDensity: VisualDensity.compact,
-                    ),
-                    Text('Duration: ${match.duration.inMinutes}m'),
-                  ],
-                )
-              else
+              if (!match.isPrivate) ...[
+                Text('Players: ${match.attendees.length}/${match.capacity}'),
+                Text('Duration: ${match.duration.inMinutes}m'),
+                Chip(
+                  label: const Text('Public'),
+                  backgroundColor: Colors.green.shade100,
+                  visualDensity: VisualDensity.compact,
+                ),
+              ] else
                 Chip(
                   label: const Text('Private'),
                   backgroundColor: Colors.red.shade100,


### PR DESCRIPTION
## Summary
- Display Public badge on its own line in game cards for consistency
- Simplify match detail background for better readability
- Expand home and leagues tabs with user info, status, and joined games

## Testing
- `npm test` *(fails: Error: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689721ba46d88329998162a19d6b73f0