### PR TITLE
Handle nullable dropdown onStatusChanged

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -91,7 +91,11 @@ class _WelcomeTab extends StatelessWidget {
                     DropdownMenuItem(value: 'Injured', child: Text('Injured')),
                     DropdownMenuItem(value: 'On Vacation', child: Text('On Vacation')),
                   ],
-                  onChanged: onStatusChanged,
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      onStatusChanged(value);
+                    }
+                  },
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- Handle nullable onChanged callback for status dropdown

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897232e36748329b76a39387d57cdc7