### PR TITLE
Fix create match button to add game and sort list

### DIFF
--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -309,6 +309,8 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
                         );
                       }
                     }
+                    UpcomingMatchesScreen.matches
+                        .sort((a, b) => a.date.compareTo(b.date));
                   });
                   Navigator.of(context).pop();
                 },

--- a/test/create_match_test.dart
+++ b/test/create_match_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:football_is_life/models/match.dart';
+import 'package:football_is_life/screens/upcoming_matches_screen.dart';
+
+void main() {
+  test('creating a match appends to list', () {
+    final original = UpcomingMatchesScreen.matches.length;
+    UpcomingMatchesScreen.matches.add(
+      Match(
+        id: 'test',
+        title: 'New Match',
+        date: DateTime.now().add(const Duration(days: 1)),
+        location: 'Test',
+        venue: 'Test Field',
+        minPlayers: 8,
+        capacity: 10,
+        isPrivate: false,
+        attendees: [],
+        waitlist: [],
+        duration: const Duration(minutes: 60),
+      ),
+    );
+    expect(UpcomingMatchesScreen.matches.length, original + 1);
+    UpcomingMatchesScreen.matches.removeWhere((m) => m.id == 'test');
+  });
+}


### PR DESCRIPTION
## Summary
- ensure newly created matches are inserted and the list is re-sorted
- add unit test confirming a new match is appended to the matches list

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68973fe5fc948329b70b02db1b89f3ff