### PR TITLE
Add Supabase integration for game queries

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'screens/login_screen.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Supabase.initialize(
+    url: 'YOUR_SUPABASE_URL',
+    anonKey: 'YOUR_SUPABASE_ANON_KEY',
+  );
   runApp(const MyApp());
 }
 

--- a/lib/services/game_service.dart
+++ b/lib/services/game_service.dart
@@ -1,0 +1,50 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Service layer for interacting with game-related tables in Supabase.
+class GameService {
+  GameService({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  final SupabaseClient _client;
+
+  /// Fetch upcoming games ordered by start time.
+  Future<List<Map<String, dynamic>>> fetchUpcomingGames() async {
+    final response = await _client
+        .from('games')
+        .select('id,title,start_time,location,cap,min,state,organizer_id')
+        .gte('start_time', DateTime.now().toUtc().toIso8601String())
+        .order('start_time');
+
+    return List<Map<String, dynamic>>.from(response);
+  }
+
+  /// Retrieve organizer contact information for a specific game.
+  Future<Map<String, dynamic>?> fetchOrganizerContact(String gameId) async {
+    final response = await _client
+        .from('organizer_contacts')
+        .select('display_name, organizer_phone')
+        .eq('game_id', gameId)
+        .maybeSingle();
+    return response;
+  }
+
+  /// As an organizer, load attendee phone numbers for a game.
+  Future<List<Map<String, dynamic>>> fetchAttendeeProfiles(String gameId) async {
+    final attendeeIds = await _client
+        .from('rsvps')
+        .select('user_id')
+        .eq('game_id', gameId) as List;
+
+    final ids = attendeeIds.map((e) => e['user_id'] as String).toList();
+    if (ids.isEmpty) {
+      return [];
+    }
+
+    final profiles = await _client
+        .from('profiles')
+        .select('id, display_name, phone')
+        .in_('id', ids) as List<dynamic>;
+
+    return List<Map<String, dynamic>>.from(profiles);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  supabase_flutter: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate `supabase_flutter` dependency
- initialize Supabase in main entrypoint
- add `GameService` with helpers to query games, organizer contacts, and attendee profiles

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689752555c848329af691e39e0aa3c07