### PR TITLE
feat: enable email magic link login

### DIFF
--- a/lib/screens/profile_setup_screen.dart
+++ b/lib/screens/profile_setup_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/user.dart';
+import 'home_screen.dart';
+
+/// Screen that collects the user's name and phone number after email login.
+class ProfileSetupScreen extends StatefulWidget {
+  const ProfileSetupScreen({super.key});
+
+  @override
+  State<ProfileSetupScreen> createState() => _ProfileSetupScreenState();
+}
+
+class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveProfile() async {
+    final name = _nameController.text.trim();
+    final phone = _phoneController.text.trim();
+    final user = Supabase.instance.client.auth.currentUser;
+    if (user == null || name.isEmpty || phone.isEmpty) {
+      return;
+    }
+    setState(() => _saving = true);
+    try {
+      await Supabase.instance.client
+          .from('profiles')
+          .update({'display_name': name, 'phone': phone})
+          .eq('id', user.id);
+    } finally {
+      setState(() => _saving = false);
+    }
+
+    final appUser = User(name: name, phone: phone, joinDate: DateTime.now());
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => HomeScreen(user: appUser)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Complete Profile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _phoneController,
+              keyboardType: TextInputType.phone,
+              decoration: const InputDecoration(labelText: 'Phone Number'),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _saving ? null : _saveProfile,
+                child:
+                    _saving ? const CircularProgressIndicator() : const Text('Save'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,18 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:football_is_life/main.dart';
 
 void main() {
-  testWidgets('Login and navigate to matches screen', (tester) async {
+  testWidgets('Email login sends magic link', (tester) async {
     await tester.pumpWidget(const MyApp());
 
-    expect(find.text('Login'), findsOneWidget);
+    expect(find.text('Send Magic Link'), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField).at(0), 'Alice');
-    await tester.enterText(find.byType(TextField).at(1), '123456');
+    await tester.enterText(
+        find.byType(TextField).first, 'test@example.com');
+    await tester.tap(find.text('Send Magic Link'));
+    await tester.pump();
 
-    await tester.tap(find.text('Login'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Welcome, Alice'), findsOneWidget);
+    expect(find.text('Check your email for a login link.'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- switch login to email-based magic links
- add profile setup screen to capture name and phone
- update widget test for new email flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689756f1ad6483298db77c4e1ae16687