### PR TITLE
feat: add send email function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -311,6 +311,13 @@ inspector_port = 8083
 # The Deno major version to use.
 deno_version = 1
 
+[functions]
+[functions.env]
+SMTP_HOST = "env(SMTP_HOST)"
+SMTP_PORT = "env(SMTP_PORT)"
+SMTP_USERNAME = "env(SMTP_USERNAME)"
+SMTP_PASSWORD = "env(SMTP_PASSWORD)"
+
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 

--- a/supabase/functions/send_email/index.ts
+++ b/supabase/functions/send_email/index.ts
@@ -1,0 +1,34 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import nodemailer from "npm:nodemailer";
+
+serve(async (req: Request) => {
+  try {
+    const { to, subject, body } = await req.json();
+
+    const transporter = nodemailer.createTransport({
+      host: Deno.env.get("SMTP_HOST"),
+      port: Number(Deno.env.get("SMTP_PORT")),
+      auth: {
+        user: Deno.env.get("SMTP_USERNAME"),
+        pass: Deno.env.get("SMTP_PASSWORD"),
+      },
+    });
+
+    await transporter.sendMail({
+      from: Deno.env.get("SMTP_USERNAME"),
+      to,
+      subject,
+      html: body,
+    });
+
+    return new Response(
+      JSON.stringify({ message: "Email sent" }),
+      { headers: { "Content-Type": "application/json" }, status: 200 },
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      { headers: { "Content-Type": "application/json" }, status: 500 },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add serverless function to send email via SMTP
- expose SMTP credentials through functions env in config

## Testing
- `npm test`
- `supabase functions deploy send_email` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897631e794083298a34305581493b76