### PR TITLE
Surface Supabase OTP errors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -101,14 +101,28 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
     });
     try {
       await supa.auth.signInWithOtp(email: _emailCtrl.text.trim());
+      if (!mounted) return;
+      setState(() {
+        _sent = true;
+        _msg = 'Check your email for the 6-digit code.';
+      });
+    } on AuthException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _msg = 'Failed to send OTP: ${e.message}';
+      });
     } catch (_) {
-      // ignore errors so tests can run offline
+      if (!mounted) return;
+      setState(() {
+        _msg = 'Failed to send OTP.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+        });
+      }
     }
-    setState(() {
-      _sent = true;
-      _msg = 'Check your email for the 6-digit code.';
-      _busy = false;
-    });
   }
 
   Future<void> _verify() async {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -41,13 +41,21 @@ class _LoginScreenState extends State<LoginScreen> {
     if (email.isEmpty) return;
     try {
       await Supabase.instance.client.auth.signInWithOtp(email: email);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Check your email for a login link.')),
+      );
+    } on AuthException catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error sending email: ${e.message}')),
+      );
     } catch (_) {
-      // ignore errors to keep tests offline
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to send email.')),
+      );
     }
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Check your email for a login link.')),
-    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- Display explicit error messages when sending login OTP fails in both OTP and magic-link flows.
- Avoid silently treating failed OTP requests as success.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897607e47e083298d122d460d7a8506