### PR TITLE
Navigate on successful OTP verification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,14 +136,31 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
         token: _otpCtrl.text.trim(),
         type: OtpType.email,
       );
-    } catch (_) {
+      // Force a re-check and navigate immediately on success
+      if (!mounted) return;
+      final user = supa.auth.currentUser;
+      print('user=${supa.auth.currentUser?.id}, session=${supa.auth.currentSession != null}');
+      if (user != null) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (_) => const HomeScreen()),
+        );
+      }
+    } on AuthException catch (e) {
+      if (!mounted) return;
       setState(() {
-        _msg = 'Verification failed.';
+        _msg = 'Verification failed: ${e.message}';
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _msg = 'Verification failed: $e';
       });
     } finally {
-      setState(() {
-        _busy = false;
-      });
+      if (mounted) {
+        setState(() {
+          _busy = false;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- route to HomeScreen after verifying OTP instead of relying solely on listener
- improve verification error handling and add debug session print

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68977bac5fdc832989548cc74b4adb4b