### PR TITLE
Show profile setup after OTP verification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,15 +136,11 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
         token: _otpCtrl.text.trim(),
         type: OtpType.email,
       );
-      // Force a re-check and navigate immediately on success
+      // AuthGate listens to auth changes and will route the user to the
+      // appropriate screen (either [PhoneCaptureScreen] or [HomeScreen]).
+      // Avoid navigating here so the post-login setup screen can appear when
+      // required.
       if (!mounted) return;
-      final user = supa.auth.currentUser;
-      print('user=${supa.auth.currentUser?.id}, session=${supa.auth.currentSession != null}');
-      if (user != null) {
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => const HomeScreen()),
-        );
-      }
     } on AuthException catch (e) {
       if (!mounted) return;
       setState(() {


### PR DESCRIPTION
## Summary
- Remove direct navigation to home after OTP sign-in so AuthGate can show the phone & name capture screen when needed.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897ae1f85dc83299742dcd43fc1d87f