### PR TITLE
Fix OTP verification to use verifyOTP

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,10 +131,9 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
       _msg = null;
     });
     try {
-      // Use `signInWithOtp` with the provided token to complete the login
-      // process. Using `verifyOTP` here results in a verified token but no
-      // active session which surfaced as an error after the last merge.
-      await supa.auth.signInWithOtp(
+      // Complete the login process by verifying the OTP. `verifyOTP` also
+      // creates an active session for the user once the code is confirmed.
+      await supa.auth.verifyOTP(
         email: _emailCtrl.text.trim(),
         token: _otpCtrl.text.trim(),
         type: OtpType.email,


### PR DESCRIPTION
## Summary
- call `verifyOTP` when validating email codes

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2206db483299313611e753233b3