### PR TITLE
fix email otp verification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -137,6 +137,7 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
         email: _emailCtrl.text.trim(),
         token: _otpCtrl.text.trim(),
         type: OtpType.email,
+        emailOtpType: EmailOtpType.email,
       );
       // AuthGate listens to auth changes and will route the user to the
       // appropriate screen (either [PhoneCaptureScreen] or [HomeScreen]).


### PR DESCRIPTION
## Summary
- specify email OTP type when verifying to complete login

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b3a408388329ae4365de6efa6759