### PR TITLE
Remove deprecated EmailOtpType parameter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -137,7 +137,6 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
         email: _emailCtrl.text.trim(),
         token: _otpCtrl.text.trim(),
         type: OtpType.email,
-        emailOtpType: EmailOtpType.email,
       );
       // AuthGate listens to auth changes and will route the user to the
       // appropriate screen (either [PhoneCaptureScreen] or [HomeScreen]).


### PR DESCRIPTION
## Summary
- adjust OTP verification to match current Supabase API

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897b514e3d083298ee9f8db11485723