### PR TITLE
Skip login screen and go straight to home

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,10 +20,14 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       title: 'Football Is Life',
-      home: AuthGate(),
+      // home: AuthGate(), // Login temporarily disabled
+      home: HomeScreen(),
     );
   }
 }
+
+/*
+// Authentication and OTP login temporarily disabled.
 
 class AuthGate extends StatefulWidget {
   const AuthGate({super.key});
@@ -221,6 +225,7 @@ class _OTPSignInScreenState extends State<OTPSignInScreen> {
     );
   }
 }
+*/
 
 class PhoneCaptureScreen extends StatefulWidget {
   const PhoneCaptureScreen({super.key});

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,3 +1,4 @@
+/*
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -118,4 +119,5 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 }
+*/
 


### PR DESCRIPTION
## Summary
- show `HomeScreen` directly and comment out OTP login widgets
- comment out legacy `LoginScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899042541e48329a26da03bc1b2b102