### PR TITLE
Add tabbed navigation for home, your games, and other games

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:phone_numbers_parser/phone_numbers_parser.dart';
 
+import 'screens/home_screen.dart';
+import 'models/user.dart' as models;
+
 SupabaseClient get supa => Supabase.instance.client;
 
 Future<void> main() async {
@@ -18,10 +21,15 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    final demoUser = models.User(
+      name: 'Player',
+      phone: '0000000000',
+      joinDate: DateTime.now(),
+    );
+    return MaterialApp(
       title: 'Football Is Life',
       // home: AuthGate(), // Login temporarily disabled
-      home: HomeScreen(),
+      home: HomeScreen(user: demoUser),
     );
   }
 }
@@ -257,8 +265,16 @@ class _PhoneCaptureScreenState extends State<PhoneCaptureScreen> {
         'phone': e164,
       }).eq('id', uid);
       if (!mounted) return;
-      Navigator.of(context)
-          .pushReplacement(MaterialPageRoute(builder: (_) => const HomeScreen()));
+      final appUser = models.User(
+        name: _nameCtrl.text.trim().isEmpty
+            ? 'Player'
+            : _nameCtrl.text.trim(),
+        phone: e164,
+        joinDate: DateTime.now(),
+      );
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => HomeScreen(user: appUser)),
+      );
     } catch (_) {
       setState(() {
         _err = 'Invalid phone or failed to save.';
@@ -308,29 +324,6 @@ class _PhoneCaptureScreenState extends State<PhoneCaptureScreen> {
               ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final user = supa.auth.currentUser;
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Games'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.logout),
-            onPressed: () => supa.auth.signOut(),
-          ),
-        ],
-      ),
-      body: Center(
-        child: Text('Welcome ${user?.email ?? 'Player'}'),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -24,8 +24,8 @@ class _HomeScreenState extends State<HomeScreen> {
         status: _status,
         onStatusChanged: (val) => setState(() => _status = val),
       ),
-      _LeaguesTab(user: widget.user),
-      UpcomingMatchesScreen(user: widget.user),
+      _YourGamesTab(user: widget.user),
+      UpcomingMatchesScreen(user: widget.user, showOnlyOthers: true),
     ];
 
     return Scaffold(
@@ -35,8 +35,10 @@ class _HomeScreenState extends State<HomeScreen> {
         onTap: (index) => setState(() => _selectedIndex = index),
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
-          BottomNavigationBarItem(icon: Icon(Icons.emoji_events), label: 'Leagues'),
-          BottomNavigationBarItem(icon: Icon(Icons.sports_soccer), label: 'Games'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.event_available), label: 'Your Games'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.sports_soccer), label: 'Other Games'),
         ],
       ),
     );
@@ -118,9 +120,9 @@ class _WelcomeTab extends StatelessWidget {
   }
 }
 
-class _LeaguesTab extends StatelessWidget {
+class _YourGamesTab extends StatelessWidget {
   final User user;
-  const _LeaguesTab({required this.user});
+  const _YourGamesTab({required this.user});
 
   @override
   Widget build(BuildContext context) {
@@ -133,13 +135,13 @@ class _LeaguesTab extends StatelessWidget {
 
     if (display.isEmpty) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Your Leagues')),
-        body: const Center(child: Text('No leagues yet')),
+        appBar: AppBar(title: const Text('Your Games')),
+        body: const Center(child: Text('No games yet')),
       );
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Your Leagues')),
+      appBar: AppBar(title: const Text('Your Games')),
       body: ListView(
         children: [
           for (final m in display)

--- a/lib/screens/upcoming_matches_screen.dart
+++ b/lib/screens/upcoming_matches_screen.dart
@@ -6,7 +6,12 @@ import 'match_detail_screen.dart';
 
 class UpcomingMatchesScreen extends StatefulWidget {
   final User user;
-  const UpcomingMatchesScreen({Key? key, required this.user}) : super(key: key);
+  final bool showOnlyOthers;
+  const UpcomingMatchesScreen({
+    Key? key,
+    required this.user,
+    this.showOnlyOthers = false,
+  }) : super(key: key);
 
   static final DateTime _now = DateTime.now();
   static final List<Match> matches = [
@@ -338,7 +343,8 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
     final weekEnd = now.add(const Duration(days: 7));
     final monthEnd = DateTime(now.year, now.month + 1, 1);
 
-    final thisWeek = otherMatches.where((m) => m.date.isBefore(weekEnd)).toList();
+    final thisWeek =
+        otherMatches.where((m) => m.date.isBefore(weekEnd)).toList();
     final thisMonth = otherMatches
         .where((m) => m.date.isBefore(monthEnd) && m.date.isAfter(weekEnd))
         .toList();
@@ -354,10 +360,14 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
       if (matches.isEmpty) return [];
       final widgets = <Widget>[
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          padding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text(
             title,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.white),
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(color: Colors.white),
           ),
         ),
       ];
@@ -366,6 +376,37 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
       }
       return widgets;
     }
+
+    final children = <Widget>[
+      Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Welcome, ${widget.user.name}',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleLarge
+                  ?.copyWith(color: Colors.white),
+            ),
+            Text(
+              'Joined on: ${widget.user.joinDate.toLocal().toString().split(' ')[0]}',
+              style: const TextStyle(color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    ];
+
+    if (!widget.showOnlyOthers) {
+      children.addAll(buildSection('Your Games', myMatches));
+    }
+
+    children.addAll(buildSection('This Week', thisWeek));
+    children.addAll(buildSection('This Month', thisMonth));
+    children.addAll(buildSection('Later', later));
+    children.add(const SizedBox(height: 80));
 
     return Scaffold(
       appBar: AppBar(
@@ -380,31 +421,7 @@ class _UpcomingMatchesScreenState extends State<UpcomingMatchesScreen>
             colorFilter: ColorFilter.mode(Colors.black38, BlendMode.darken),
           ),
         ),
-        child: ListView(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Welcome, ${widget.user.name}',
-                    style: Theme.of(context).textTheme.titleLarge?.copyWith(color: Colors.white),
-                  ),
-                  Text(
-                    'Joined on: ${widget.user.joinDate.toLocal().toString().split(' ')[0]}',
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                ],
-              ),
-            ),
-            ...buildSection('Your Games', myMatches),
-            ...buildSection('This Week', thisWeek),
-            ...buildSection('This Month', thisMonth),
-            ...buildSection('Later', later),
-            const SizedBox(height: 80),
-          ],
-        ),
+        child: ListView(children: children),
       ),
       floatingActionButton: ScaleTransition(
         scale: Tween(begin: 0.9, end: 1.1).animate(


### PR DESCRIPTION
## Summary
- Add bottom navigation with Home, Your Games, and Other Games tabs
- Filter upcoming matches to optionally hide user's games
- Initialize app with demo user and route profile setup to new HomeScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899068464a483299aff1ea297f81692