### PR TITLE
Fix const usage in logged out screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -177,9 +177,9 @@ class _LoggedOutScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('Signed out')),
-      body: Center(child: Text('You have been logged out.')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Signed out')),
+      body: const Center(child: Text('You have been logged out.')),
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix logout screen scaffold to avoid const violation

## Testing
- `dart format lib/screens/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68990e1cf7708329b06e95a29ab35dd9